### PR TITLE
Fixing pagination, needed sort field to get correct records

### DIFF
--- a/src/CleanArchitecture/Application/Common/Models/BaseModel.cs
+++ b/src/CleanArchitecture/Application/Common/Models/BaseModel.cs
@@ -1,0 +1,6 @@
+﻿namespace CleanArchitecture.Application.Common.Models;
+
+public abstract class BaseModel
+{
+    public int Id { get; set; }
+}

--- a/src/CleanArchitecture/Application/Services/BookService.cs
+++ b/src/CleanArchitecture/Application/Services/BookService.cs
@@ -12,7 +12,13 @@ public class BookService(IUnitOfWork unitOfWork, IMapper mapper) : IBookService
 
     public async Task<Pagination<Book>> Get(int pageIndex, int pageSize)
     {
-        var books = await _unitOfWork.BookRepository.ToPagination(pageIndex, pageSize);
+        var books = await _unitOfWork.BookRepository.ToPagination(
+            pageIndex:pageIndex, 
+            pageSize: pageSize,
+            orderBy: x => x.Title,
+            ascending:true
+            );
+
         return books;
     }
 

--- a/src/CleanArchitecture/Domain/Entities/Book.cs
+++ b/src/CleanArchitecture/Domain/Entities/Book.cs
@@ -1,8 +1,9 @@
+using CleanArchitecture.Application.Common.Models;
+
 namespace CleanArchitecture.Domain.Entities;
 
-public class Book
+public class Book: BaseModel
 {
-    public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public double? Price { get; set; }

--- a/src/CleanArchitecture/Domain/Entities/User.cs
+++ b/src/CleanArchitecture/Domain/Entities/User.cs
@@ -1,8 +1,9 @@
+using CleanArchitecture.Application.Common.Models;
+
 namespace CleanArchitecture.Domain.Entities;
 
-public class User
+public class User: BaseModel
 {
-    public int Id { get; set; }
     public string UserName { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;

--- a/src/CleanArchitecture/Infrastructure/Interface/IGenericRepository.cs
+++ b/src/CleanArchitecture/Infrastructure/Interface/IGenericRepository.cs
@@ -3,7 +3,7 @@ using CleanArchitecture.Application.Common.Models;
 
 namespace CleanArchitecture.Infrastructure.Interface;
 
-public interface IGenericRepository<T> where T : class
+public interface IGenericRepository<T> where T : BaseModel
 {
     public Task AddAsync(T entity);
     public Task AddRangeAsync(IEnumerable<T> entities);
@@ -15,8 +15,10 @@ public interface IGenericRepository<T> where T : class
     public Task<Pagination<T>> GetAsync(
        Expression<Func<T, bool>> filter,
        int pageIndex = 0,
-       int pageSize = 10);
-    public Task<Pagination<T>> ToPagination(int pageIndex, int pageSize);
+       int pageSize = 10, 
+       Expression<Func<T, object>>? orderBy = null, 
+       bool ascending = true);
+    public Task<Pagination<T>> ToPagination(int pageIndex, int pageSize, Expression<Func<T, object>>? orderBy = null, bool ascending = true);
 
     public Task<T> FirstOrDefaultAsync(Expression<Func<T, bool>> filter);
     public void Update(T entity);


### PR DESCRIPTION
Before a skip take, the records must be sorted in order to have the correct records. A base class was created for the models with the Id property. The Book and User models now extend the BaseModel class, with which it can be assumed that all entities can sort their records by the Id field.

![image](https://github.com/user-attachments/assets/c08ac312-40f2-4386-a90b-40641015977d)

![image](https://github.com/user-attachments/assets/00486cd4-7ec0-4579-93da-c7038717a921)

The possibility of sorting by a specific field in ascending or descending order with default values ​​has been added. If no sorting field or sorting method is sent, the records will be sorted by ID in ascending order:

![image](https://github.com/user-attachments/assets/ffa2b9cb-9f06-4c8c-b88f-bb2b02e08593)

In the service, the sorting field is selected, although by default it has Id, it makes more sense to sort it by the title. If necessary, the sorting field can also be parameterized in the future:

![image](https://github.com/user-attachments/assets/a5a3ada9-ec21-4870-a426-26d939fda544)

